### PR TITLE
fix: 메세지 읽음확인 수정

### DIFF
--- a/src/main/java/com/phcworld/domain/message/ChatRoomMessage.java
+++ b/src/main/java/com/phcworld/domain/message/ChatRoomMessage.java
@@ -8,10 +8,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Setter
 @EntityListeners(AuditingEntityListener.class)
 @Table(indexes = @Index(name = "idx__chat_room_id_send_date", columnList = "chat_room_id, sendDate"))
 @DynamicUpdate
@@ -32,20 +34,22 @@ public class ChatRoomMessage {
     @CreatedDate
     private LocalDateTime sendDate;
 
-    private Boolean isRead;
+    @OneToMany(mappedBy = "message")
+    private List<MessageReadUser> readUsers;
 
     @Builder
-    public ChatRoomMessage(Long id, ChatRoom chatRoom, User writer, String message, LocalDateTime sendDate, Boolean isRead) {
+    public ChatRoomMessage(Long id, ChatRoom chatRoom, User writer, String message, LocalDateTime sendDate, List<MessageReadUser> readUsers) {
         this.id = id;
         this.chatRoom = chatRoom;
         this.writer = writer;
         this.message = message;
         this.sendDate = sendDate;
-        this.isRead = isRead;
+        this.readUsers = readUsers;
     }
 
     public void deleteMessage() {
         this.message = "deleted";
+        this.readUsers = null;
     }
 
     public boolean isSameWriter(User loginUser) {
@@ -58,6 +62,10 @@ public class ChatRoomMessage {
 
     public String getWriterProfileImage() {
         return writer.getProfileImage();
+    }
+
+    public void removeReadUser(MessageReadUser readUser) {
+        this.readUsers.remove(readUser);
     }
 }
 

--- a/src/main/java/com/phcworld/domain/message/MessageReadUser.java
+++ b/src/main/java/com/phcworld/domain/message/MessageReadUser.java
@@ -1,0 +1,31 @@
+package com.phcworld.domain.message;
+
+import com.phcworld.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageReadUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne
+    private ChatRoomMessage message;
+
+    public boolean readUser(User loginUser) {
+        return this.user.equals(loginUser);
+    }
+}

--- a/src/main/java/com/phcworld/domain/message/dto/ChatRoomMessageResponseDto.java
+++ b/src/main/java/com/phcworld/domain/message/dto/ChatRoomMessageResponseDto.java
@@ -8,13 +8,14 @@ import lombok.ToString;
 
 @Builder
 @Getter
+@ToString
 public class ChatRoomMessageResponseDto {
     private Long messageId;
     private String message;
     private String writerName;
     private String writerImgUrl;
     private String sendDate;
-    private String read;
+    private Integer readCount;
 
     public static ChatRoomMessageResponseDto of(ChatRoomMessage message){
         return ChatRoomMessageResponseDto.builder()
@@ -23,7 +24,18 @@ public class ChatRoomMessageResponseDto {
                 .writerName(message.getWriterName())
                 .writerImgUrl(message.getWriterProfileImage())
                 .sendDate(LocalDateTimeUtils.getTime(message.getSendDate()))
-                .read(message.getIsRead() ? "읽음" : "읽지 않음")
+                .readCount(message.getReadUsers().size())
+                .build();
+    }
+
+    public static ChatRoomMessageResponseDto of(MessageSelectDto message){
+        return ChatRoomMessageResponseDto.builder()
+                .messageId(message.getMessageId())
+                .message(message.getMessage())
+                .writerName(message.getWriterName())
+                .writerImgUrl(message.getProfileImgUrl())
+                .sendDate(LocalDateTimeUtils.getTime(message.getSendDate()))
+                .readCount(message.getReadUsers().size())
                 .build();
     }
 }

--- a/src/main/java/com/phcworld/domain/message/dto/ChatRoomSelectDto.java
+++ b/src/main/java/com/phcworld/domain/message/dto/ChatRoomSelectDto.java
@@ -18,10 +18,14 @@ public class ChatRoomSelectDto {
     private Long chatRoomId;
     private List<String> users;
     private String lastMessage;
-    private Boolean isRead;
+    private Integer count;
     private LocalDateTime date;
 
     public String getDate(){
         return LocalDateTimeUtils.getTime(date);
+    }
+
+    public String getRead(){
+        return count == 0 ? "읽음" : "읽지 않음";
     }
 }

--- a/src/main/java/com/phcworld/domain/message/dto/MessageResponseDto.java
+++ b/src/main/java/com/phcworld/domain/message/dto/MessageResponseDto.java
@@ -15,6 +15,7 @@ public class MessageResponseDto {
     private String message;
     private String sendDate;
     private Long chatRoomId;
+    private Integer readCount;
 
     public static MessageResponseDto of(ChatRoomMessage message){
         return MessageResponseDto.builder()
@@ -23,6 +24,7 @@ public class MessageResponseDto {
                 .message(message.getMessage())
                 .sendDate(message.getSendDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")))
                 .chatRoomId(message.getChatRoom().getId())
+                .readCount(message.getReadUsers() != null ? message.getReadUsers().size() : 0)
                 .build();
     }
 }

--- a/src/main/java/com/phcworld/domain/message/dto/MessageSelectDto.java
+++ b/src/main/java/com/phcworld/domain/message/dto/MessageSelectDto.java
@@ -1,0 +1,23 @@
+package com.phcworld.domain.message.dto;
+
+import com.phcworld.domain.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class MessageSelectDto {
+    private Long messageId;
+    private String writerName;
+    private String profileImgUrl;
+    private String message;
+    private LocalDateTime sendDate;
+    private List<User> readUsers;
+
+    public void removeReadUser(User readUser) {
+        this.readUsers.remove(readUser);
+    }
+}

--- a/src/main/java/com/phcworld/repository/message/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/phcworld/repository/message/ChatRoomRepositoryCustom.java
@@ -2,12 +2,15 @@ package com.phcworld.repository.message;
 
 import com.phcworld.domain.message.ChatRoom;
 import com.phcworld.domain.message.dto.ChatRoomSelectDto;
+import com.phcworld.domain.message.dto.MessageSelectDto;
 import com.phcworld.domain.user.User;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
 public interface ChatRoomRepositoryCustom {
 
     List<ChatRoomSelectDto> findChatRoomListByUser(User user);
-    ChatRoom findByChatRoomByUsers(List<Long> ids);
+    ChatRoom findChatRoomByUsers(List<Long> ids);
+    List<MessageSelectDto> findMessagesByChatRoom(ChatRoom chatRoom, PageRequest pageRequest);
 }

--- a/src/main/java/com/phcworld/repository/message/MessageReadUserRepository.java
+++ b/src/main/java/com/phcworld/repository/message/MessageReadUserRepository.java
@@ -1,0 +1,7 @@
+package com.phcworld.repository.message;
+
+import com.phcworld.domain.message.MessageReadUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageReadUserRepository extends JpaRepository<MessageReadUser, Long> {
+}

--- a/src/test/java/com/phcworld/service/message/ChatServiceTest.java
+++ b/src/test/java/com/phcworld/service/message/ChatServiceTest.java
@@ -48,6 +48,7 @@ public class ChatServiceTest {
         MessageResponseDto responseDto = chatService.sendMessage(loginUser, dto);
         assertThat(responseDto.getMessage()).isEqualTo(dto.getMessage());
         assertThat(responseDto.getWriterName()).isEqualTo(loginUser.getName());
+        assertThat(responseDto.getReadCount()).isEqualTo(1);
     }
 
     @Test
@@ -103,6 +104,9 @@ public class ChatServiceTest {
         MessageResponseDto message = chatService.sendMessage(loginUser, dto);
         User user2 = User.builder()
                 .id(2L)
+                .email("test2@test.test")
+                .name("테스트2")
+                .authority("ROLE_USER")
                 .build();
         ids.clear();
         ids.add(1L);
@@ -114,6 +118,9 @@ public class ChatServiceTest {
         em.clear();
         List<ChatRoomMessageResponseDto> messages = chatService.getMessagesByChatRoom(message.getChatRoomId(), 1, loginUser);
         assertThat(messages.size()).isEqualTo(2);
+        assertThat(messages.get(0).getReadCount()).isEqualTo(0);
+        assertThat(messages.get(1).getReadCount()).isEqualTo(1);
+
     }
 
     @Test

--- a/src/test/java/com/phcworld/web/message/ChatControllerTest.java
+++ b/src/test/java/com/phcworld/web/message/ChatControllerTest.java
@@ -1,6 +1,7 @@
 package com.phcworld.web.message;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phcworld.domain.message.MessageReadUser;
 import com.phcworld.domain.message.dto.ChatRoomSelectDto;
 import com.phcworld.domain.message.dto.MessageRequestDto;
 import com.phcworld.domain.message.dto.MessageResponseDto;
@@ -76,7 +77,8 @@ public class ChatControllerTest {
                 .chatRoomId(1L)
                 .users(names)
                 .lastMessage("hi")
-                .isRead(false)
+//                .isRead(false)
+                .count(0)
                 .date(LocalDateTime.now())
                 .build();
 
@@ -95,7 +97,7 @@ public class ChatControllerTest {
                 .andExpect(jsonPath("$[0].users[0]").value("테스트"))
                 .andExpect(jsonPath("$[0].users[1]").value("테스트2"))
                 .andExpect(jsonPath("$[0].lastMessage").value("hi"))
-                .andExpect(jsonPath("$[0].isRead").value(false))
+//                .andExpect(jsonPath("$[0].isRead").value(false))
                 .andExpect(jsonPath("$[0].date").value("방금전"))
                 .andDo(print());
     }
@@ -153,7 +155,7 @@ public class ChatControllerTest {
                 .andExpect(jsonPath("$[0].message").value("hi"))
                 .andExpect(jsonPath("$[0].writerName").value(user.getName()))
                 .andExpect(jsonPath("$[0].writerImgUrl").value(user.getProfileImage()))
-                .andExpect(jsonPath("$[0].read").value("읽지 않음"))
+//                .andExpect(jsonPath("$[0].read").value("읽지 않음"))
                 .andExpect(jsonPath("$[0].sendDate").value("방금전"))
                 .andDo(print());
     }


### PR DESCRIPTION
- 다수의 회원과 대화하면 메세지를 보낸 회원 이외의 회원 수를 DB TABLE에 저장해서 카운트로 계산
- 메세지리르 보낸 회원 이외에 회원들이 메세지를 읽어야 카운트가 0이 되며 대화방 목록에서 읽음으로 나옴
- 메세지를 읽은 회원은 DB row를 삭제
- 따로 column을 update할 방법을 생각했으나 삭제가 데이터가 쌓이는 것보다 삭제가 더 좋다고 판단
- 메세지 목록을 가져오는 쿼리는 쿼리메소드와 querydsl로 작성한 쿼리 두개가 있음
- 쿼리메소드는 querydsl보다 조인문이 적지만 select쿼리가 두번이라 데이터가 쌓이면 어떤 쿼리가 성능에 좋을 테스트해볼 예정